### PR TITLE
Run generated app after maven test

### DIFF
--- a/androidkickstartr-core/src/test/java/com/athomas/androidkickstartr/KickstartrMavenTest.java
+++ b/androidkickstartr-core/src/test/java/com/athomas/androidkickstartr/KickstartrMavenTest.java
@@ -63,6 +63,7 @@ public class KickstartrMavenTest {
 		goals.add("clean");
 		goals.add("install");
 		goals.add("android:deploy");
+		goals.add("android:run");
 		request.setGoals(goals);
 		request.setShowErrors(true);
 		request.setDebug(false);


### PR DESCRIPTION
Maven unit tests are really useful in this project because the generated app is deployed if a device is connected but we have to run the app manually for each test.

`android:run` allows to run the app automatically if it is deployed.

Quite useful :)
