### PR TITLE
Should fix a conflict between acra and sample

### DIFF
--- a/androidkickstartr-core/src/main/java/com/athomas/androidkickstartr/Kickstartr.java
+++ b/androidkickstartr-core/src/main/java/com/athomas/androidkickstartr/Kickstartr.java
@@ -195,7 +195,7 @@ public class Kickstartr {
 			generators.add(new RestClientGenerator(appDetails));
 		}
 
-		if (appDetails.isAcra() && appDetails.isSample()) {
+		if (appDetails.isAcra()) {
 			generators.add(new ApplicationGenerator(appDetails));
 		}
 

--- a/androidkickstartr-core/src/main/resources/templates/ActivityMain.ftl
+++ b/androidkickstartr-core/src/main/resources/templates/ActivityMain.ftl
@@ -3,7 +3,7 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent" >
 
-	<#if !application.sample>
+	<#if application.sample>
 	<#if application.viewPager>
 	<android.support.v4.view.ViewPager
 		android:id="@+id/pager"


### PR DESCRIPTION
I just found out that the app crashes when we use ACRA and no sample in the same project. Indeed, at runtime, ACRA is looking for a class named MyAppApplication (*example in tests), but this class does not exist since we deactivated sample generation. Therefore, it leads the app to crash at runtime.

I guess the best way to solve this bug is to generate this class in any case. That's what this commit does.
